### PR TITLE
Address the security issue of basic auth over HTTP

### DIFF
--- a/app/src/main/java/model/NsApiParser.java
+++ b/app/src/main/java/model/NsApiParser.java
@@ -21,10 +21,10 @@ import java.util.concurrent.ExecutionException;
  */
 public class NsApiParser implements NamedLocationProvider {
 
-    private static final String PROTOCOL = "http";
+    private static final String PROTOCOL = "https";
     private static final String HOST = "webservices.ns.nl";
     private static final String ENDPOINT = "/ns-api-stations-v2";
-    private static final String ENCODED_AUTH = "YXJuZWRpZWhsOTZAZ21haWwuY29tOlFBY25RR2VBNGowSlNHVENWUmp6NF9BVUpOWkVKX2RsSW1mbGkzZ3FYYi14WlE5eVVBNFl2UQ==";
+    private static final String ENCODED_AUTH = null; //TODO: not to hardcode in the application, for example loading from a configuration file instead.
 
     private final Collection<NamedLocation> stations;
 


### PR DESCRIPTION
Hi @OrangeCobras,

I noticed this repository uses basic authentication over HTTP. Basic authentication only obfuscates username/password in Base64 encoding, which can be easily recognized and reversed. The hardcoded credentials (username and password) in the `NsApiParser.java` program is actually:
`arnediehl96@gmail.com:QAcnQGeA4j0JSGTCVRjz4_AUJNZEJ_dlImfli3gqXb-xZQ9yUA4YvQ`

And transmission of sensitive information not in HTTPS is vulnerable to interception by networking devices and packet sniffing.

To address the issue, credentials shall not be hardcoded in the application and the transport protocol shall be changed to HTTPS. Please consider to merge the PR.

Thanks,
@luchua-bc